### PR TITLE
Tweak formatting of input digest diffs

### DIFF
--- a/src/main/java/com/airbnb/execlog_parser/ExecLogParser.kt
+++ b/src/main/java/com/airbnb/execlog_parser/ExecLogParser.kt
@@ -78,11 +78,16 @@ object ExecLogParser {
       }
     }
     if (inputDigestDiffs.isNotEmpty()) {
-      println("Execution logs have unexpected hash diffs, indicating the build is not deterministic")
-      println("Consider adding the path to the allowlist if its impact is small.  Otherwise, please fix")
+      println("Execution logs have unexpected hash diffs, indicating the build is not deterministic.")
+      println("Consider adding the path to the allowlist if its impact is small.  Otherwise, please fix!")
+      println("")
       println("input file digests:")
+      println("")
       inputDigestDiffs.forEach {
-        println("${it.key}: ${it.value.first} ${it.value.second}")
+        println("${it.key}:")
+        println("")
+        println(it.value.first)
+        println(it.value.second)
       }
       throw Exception("Execution logs have different hashes for the same input")
     }


### PR DESCRIPTION
The current formatting ends up looking like this:

```
bazel-out/k8-fastbuild/bin/path/to/file.tar.gz: hash: "b5b1169371c657146115147232068d1a04e88ca52df7de4f522bbc9fc3209606"
size_bytes: 428915
hash_function_name: "SHA-256"
 hash: "747563ba65ac0f390ef1c983d189cdfeb6abb24c14b57ac34e9f101e6b847696"
size_bytes: 428914
hash_function_name: "SHA-256"

```

I am hoping to make this more readable. With this change I think the
format will end up looking more like this:

```
bazel-out/k8-fastbuild/bin/path/to/file.tar.gz:

hash: "b5b1169371c657146115147232068d1a04e88ca52df7de4f522bbc9fc3209606"
size_bytes: 428915
hash_function_name: "SHA-256"

hash: "747563ba65ac0f390ef1c983d189cdfeb6abb24c14b57ac34e9f101e6b847696"
size_bytes: 428914
hash_function_name: "SHA-256"

```

I think this could be taken a step further to collapse the hash and
hash_function_name onto the same line like this:

```
bazel-out/k8-fastbuild/bin/path/to/file.tar.gz:

SHA-256: "b5b1169371c657146115147232068d1a04e88ca52df7de4f522bbc9fc3209606"
size_bytes: 428915

SHA-256: "747563ba65ac0f390ef1c983d189cdfeb6abb24c14b57ac34e9f101e6b847696"
size_bytes: 428914

```

But I'm not familiar with the shape of these digests so I didn't want to
bake in any logic to do this if it doesn't always apply.

This could also potentially be improved by producing a diff, like this:

```diff
 bazel-out/k8-fastbuild/bin/path/to/file.tar.gz:

-SHA-256: "b5b1169371c657146115147232068d1a04e88ca52df7de4f522bbc9fc3209606"
+SHA-256: "747563ba65ac0f390ef1c983d189cdfeb6abb24c14b57ac34e9f101e6b847696"
-size_bytes: 428915
+size_bytes: 428914
```

But I decided to keep this change relatively simple for now.